### PR TITLE
refactor: improve bot commands, safety, caching and compatibility

### DIFF
--- a/Emilia/__init__.py
+++ b/Emilia/__init__.py
@@ -8,7 +8,6 @@ from logging.handlers import QueueHandler, QueueListener, RotatingFileHandler
 
 import orjson
 import redis.asyncio as redis
-import uvloop
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from motor import motor_asyncio
 from pymongo.errors import DuplicateKeyError
@@ -18,10 +17,12 @@ from Emilia.config import Development as Config
 from Emilia.utils.ads import install_ad_hooks
 from Emilia.utils.trace import TRACE_ID
 
-# Must run before any event loop is created (clients, schedulers, motor).
-# Sole entry point for the whole process tree — every client/scheduler
-# inherits uvloop.
-uvloop.install()
+# Try to install uvloop for performance on supported platforms
+try:
+    import uvloop
+    uvloop.install()
+except ImportError:
+    pass
 
 
 # trace.py has no Emilia deps; import at module top so JSONFormatter never does a

--- a/Emilia/__main__.py
+++ b/Emilia/__main__.py
@@ -5,7 +5,11 @@ import traceback
 from os.path import dirname
 from sys import platform
 
-import uvloop
+try:
+    import uvloop
+    has_uvloop = True
+except ImportError:
+    has_uvloop = False
 from pyrogram import idle
 
 from Emilia import LOGGER, create_indexes, pgram
@@ -328,7 +332,10 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        uvloop.run(main())
+        if has_uvloop:
+            uvloop.run(main())
+        else:
+            asyncio.run(main())
     except KeyboardInterrupt:
         LOGGER.info("Bot stopped via KeyboardInterrupt.")
     finally:

--- a/Emilia/info/chatbot_info.py
+++ b/Emilia/info/chatbot_info.py
@@ -9,5 +9,7 @@ Basically, there is chatbot inserted in {BOT_NAME}, it can be used to talk in a 
 
 **Commands**:
 
-• /chatbot: Shows chatbot control panel
+• /chatbot [enable|disable]: Enable or disable chatbot in the group.
+• /chat `<message>`: Directly converse with the chatbot.
+• /reset: Reset your conversation history.
 """

--- a/Emilia/info/misc_info.py
+++ b/Emilia/info/misc_info.py
@@ -19,4 +19,6 @@ An "odds and ends" module for small, simple commands which don't really fit anyw
 • /unzip: reply to a telegram file to decompress it from the .zip format
 
 • /count: Count total messages of a chat
+
+• /weather `<city>`: Get current weather conditions for a city.
 """

--- a/Emilia/modules/commands/carbon.py
+++ b/Emilia/modules/commands/carbon.py
@@ -58,14 +58,29 @@ async def cba(client, message):
         adjust_width=True,
         theme=random.choice(["seti", "Night Owl", "One Dark"]),
     )
+    import uuid
+    unique_id = uuid.uuid4().hex
+    base_name = f"carbon_{unique_id}"
+    full_name = f"{base_name}.png"
+
     cb = carbon.Carbon()
     try:
         img = await cb.generate(options)
+        await img.save(base_name)
+        await message.reply_photo(full_name, reply_parameters=None)
     except Exception as e:
         LOGGER.error(e)
         await message.reply_text(
             f"Some error occured! Please report to @{SUPPORT_CHAT}"
         )
-    await img.save("carbon")
-    await message.reply_photo("carbon.png", reply_parameters=None)
-    await res.delete()
+    finally:
+        try:
+            await res.delete()
+        except Exception:
+            pass
+        if os.path.exists(full_name):
+            try:
+                os.remove(full_name)
+            except Exception:
+                pass
+

--- a/Emilia/modules/commands/chatbot.py
+++ b/Emilia/modules/commands/chatbot.py
@@ -15,6 +15,7 @@ from Emilia import BOT_ID, CARTESIA_API_KEY, GROQ_API_KEY, LOGGER, db
 from Emilia.custom_filter import listen, register
 from Emilia.helper.admins import is_admin
 from Emilia.utils.async_http import post as async_post
+from Emilia.utils.decorators import rate_limit, RATE_LIMIT_GENERAL
 
 # ─── Configuration ──────────────────────────────────────────────────────
 
@@ -49,6 +50,9 @@ if not voice_enabled:
 
 chatbotdb = db.chatbotto
 convodb = db.gemini_convos
+
+from Emilia.utils.cache import SimpleCache
+chatbot_cache = SimpleCache(default_ttl=600, namespace="chatbot_enabled")
 
 
 # ─── Tool Definition ────────────────────────────────────────────────────
@@ -492,12 +496,52 @@ async def chatbotcheck(client, message):
             {"$set": {"chat_id": message.chat.id}},
             upsert=True,
         )
+        await chatbot_cache.set(f"enabled:{message.chat.id}", True)
         await message.reply_text("Chatbot enabled.")
     elif cmd in ("disable", "off", "no"):
         await chatbotdb.delete_one({"chat_id": message.chat.id})
+        await chatbot_cache.set(f"enabled:{message.chat.id}", False)
         await message.reply_text("Chatbot disabled.")
     else:
         await message.reply_text("Invalid argument. Use enable or disable.")
+
+
+@register(pattern="chat")
+@rate_limit(RATE_LIMIT_GENERAL)
+async def chat_cmd(client, message):
+    try:
+        query = message.text.split(None, 1)[1].strip()
+    except IndexError:
+        await message.reply_text("Usage: /chat [message]")
+        return
+
+    if not query:
+        await message.reply_text("Usage: /chat [message]")
+        return
+
+    await client.send_chat_action(message.chat.id, ChatAction.TYPING)
+    response = await handleChatRequest(message, query)
+
+    if not response:
+        await message.reply_text(random.choice(RANDOM_RESPONSES))
+        return
+
+    # Voice response
+    if response.type == "voice" and response.voice_text:
+        ogg_path = None
+        try:
+            await client.send_chat_action(message.chat.id, ChatAction.RECORD_AUDIO)
+            ogg_path = await generate_voice_note(response.voice_text)
+            if ogg_path:
+                await message.reply_voice(ogg_path)
+            else:
+                await sendResponse(message, response.voice_text)
+        finally:
+            _safe_remove(ogg_path)
+        return
+
+    # Text response
+    await sendResponse(message, response.text or "")
 
 
 @register(pattern="reset")
@@ -532,7 +576,14 @@ async def message_handler(client, message):
     if not message.reply_to_message_id:
         return
 
-    if not await chatbotdb.find_one({"chat_id": message.chat.id}):
+    chat_id = message.chat.id
+    cache_key = f"enabled:{chat_id}"
+    enabled = await chatbot_cache.get(cache_key)
+    if enabled is None:
+        doc = await chatbotdb.find_one({"chat_id": chat_id})
+        enabled = bool(doc)
+        await chatbot_cache.set(cache_key, enabled)
+    if not enabled:
         return
 
     reply = message.reply_to_message

--- a/Emilia/modules/commands/logomaker.py
+++ b/Emilia/modules/commands/logomaker.py
@@ -289,12 +289,26 @@ async def lego(client, message):
 
     pesan = await message.reply_text("Logo In A Process. Please Wait.")
 
-    randc = random.choice(LOGO_LINKS)
-    response = await get(randc)
-    fname = "Emilia.png"
-    await asyncio.to_thread(_render_logo, response.content, text, fname)
-    await client.send_photo(message.chat.id, fname)
-    await pesan.delete()
+    import uuid
+    unique_id = uuid.uuid4().hex
+    fname = f"logo_{unique_id}.png"
 
-    if os.path.exists(fname):
-        os.remove(fname)
+    try:
+        randc = random.choice(LOGO_LINKS)
+        response = await get(randc)
+        await asyncio.to_thread(_render_logo, response.content, text, fname)
+        await client.send_photo(message.chat.id, fname)
+    except Exception as e:
+        LOGGER.error(f"Error in logo maker: {e}")
+        await message.reply_text("Something went wrong while generating the logo.")
+    finally:
+        try:
+            await pesan.delete()
+        except Exception:
+            pass
+        if os.path.exists(fname):
+            try:
+                os.remove(fname)
+            except Exception:
+                pass
+

--- a/Emilia/modules/commands/misc.py
+++ b/Emilia/modules/commands/misc.py
@@ -16,8 +16,8 @@ from Emilia.utils.async_http import get
 from Emilia.utils.decorators import *
 
 
-def _synthesize_tts(text, lang):
-    gTTS(text, tld="com", lang=lang).save("stt.mp3")
+def _synthesize_tts(text, lang, filename):
+    gTTS(text, tld="com", lang=lang).save(filename)
 
 
 @register(pattern="(count|gstat)")
@@ -50,22 +50,29 @@ async def tts(client, message):
             lang = "en"
     else:
         return await usage_string(message, tts)
+    import uuid
+    filename = f"stt_{uuid.uuid4().hex}.mp3"
     try:
-        await asyncio.to_thread(_synthesize_tts, text, lang)
+        await asyncio.to_thread(_synthesize_tts, text, lang, filename)
+        aud_len = int((MP3(filename)).info.length)
+        if aud_len == 0:
+            aud_len = 1
+        await client.send_chat_action(message.chat.id, ChatAction.RECORD_AUDIO)
+        await message.reply_audio(
+            filename,
+            reply_parameters=None,
+            duration=aud_len,
+            title=f"stt_{lang}",
+            performer=f"{BOT_NAME}",
+        )
     except BaseException as e:
         return await message.reply_text(str(e))
-    aud_len = int((MP3("stt.mp3")).info.length)
-    if aud_len == 0:
-        aud_len = 1
-    await client.send_chat_action(message.chat.id, ChatAction.RECORD_AUDIO)
-    await message.reply_audio(
-        "stt.mp3",
-        reply_parameters=None,
-        duration=aud_len,
-        title=f"stt_{lang}",
-        performer=f"{BOT_NAME}",
-    )
-    os.remove("stt.mp3")
+    finally:
+        if os.path.exists(filename):
+            try:
+                os.remove(filename)
+            except Exception:
+                pass
 
 
 # DONE: GIFs

--- a/Emilia/modules/commands/truthdare.py
+++ b/Emilia/modules/commands/truthdare.py
@@ -1,6 +1,33 @@
+import random
 from Emilia.custom_filter import register
 from Emilia.helper.disable import disable
 from Emilia.utils.async_http import get
+
+TRUTHS = [
+    "What is your biggest fear?",
+    "What is the most embarrassing thing you've ever done?",
+    "Have you ever lied to your best friend?",
+    "What is a secret you've never told anyone?",
+    "If you could trade places with anyone for a day, who would it be?",
+    "What is the strangest dream you've ever had?",
+    "Have you ever had a crush on a teacher or boss?",
+    "What is your worst habit?",
+    "What is the most childish thing you still do?",
+    "Have you ever cheated on a test or exam?"
+]
+
+DARES = [
+    "Do 10 pushups right now.",
+    "Send the last photo in your gallery to this chat.",
+    "Send a voice note singing a song of your choice.",
+    "Text a friend 'I love you' and send a screenshot of their reaction.",
+    "Speak in an accent of the group's choice for the next 10 minutes.",
+    "Tell the group a joke that makes them laugh.",
+    "Type a message using only your nose.",
+    "Show the last 3 search items on your search history.",
+    "Send a funny selfie to this group.",
+    "Make up a short story about the first person to talk after you."
+]
 
 
 async def fetch_question(url):
@@ -24,13 +51,16 @@ async def get_truth_question():
 @disable
 async def dare(client, event):
     dare = await get_dare_question()
-    if dare:
-        await event.reply(f"{dare}")
+    if not dare:
+        dare = random.choice(DARES)
+    await event.reply(f"{dare}")
 
 
 @register(pattern="truth", disable=True)
 @disable
 async def truth(client, event):
     truth = await get_truth_question()
-    if truth:
-        await event.reply(f"{truth}")
+    if not truth:
+        truth = random.choice(TRUTHS)
+    await event.reply(f"{truth}")
+

--- a/Emilia/modules/commands/ud.py
+++ b/Emilia/modules/commands/ud.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from pyrogram.errors import ChatWriteForbidden
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
@@ -19,13 +20,16 @@ async def get_ud_definition(text):
 @register(pattern="ud", disable=True)
 @disable
 async def ud_command(client, message):
-    words = (message.text or "").split(" ")
-
-    if len(words) != 2:
-        await message.reply_text("Please provide only one word.")
+    try:
+        text = message.text.split(None, 1)[1].strip()
+    except IndexError:
+        await message.reply_text("Please provide a search term (word or phrase).")
         return
 
-    text = words[1]
+    if not text:
+        await message.reply_text("Please provide a search term (word or phrase).")
+        return
+
     result = await get_ud_definition(text)
 
     if result:
@@ -40,7 +44,7 @@ async def ud_command(client, message):
     else:
         reply_text = "No results found."
 
-    search_url = f"https://www.google.com/search?q={text}"
+    search_url = f"https://www.google.com/search?q={urllib.parse.quote(text)}"
     buttons = InlineKeyboardMarkup(
         [[InlineKeyboardButton("🔎 Google it!", url=search_url)]]
     )
@@ -48,18 +52,24 @@ async def ud_command(client, message):
     try:
         await message.reply_text(reply_text, reply_markup=buttons)
     except ChatWriteForbidden:
-        await message.reply_text(reply_text)
+        try:
+            await message.reply_text(reply_text)
+        except Exception:
+            pass
 
 
 @register(pattern="define", disable=True)
 @disable
 async def define_command(client, message):
-    user_input = (message.text or "").split(None, 1)[1]
+    try:
+        user_input = message.text.split(None, 1)[1].strip()
+    except IndexError:
+        return await message.reply_text("Please provide a word to define!")
 
     if not user_input:
         return await message.reply_text("Please provide a word to define!")
 
-    url = "https://api.dictionaryapi.dev/api/v2/entries/en/{}".format(user_input)
+    url = "https://api.dictionaryapi.dev/api/v2/entries/en/{}".format(urllib.parse.quote(user_input))
     response = await get(url)
 
     try:
@@ -77,3 +87,4 @@ async def define_command(client, message):
         pass
 
     await message.reply_text("__No results found.__")
+

--- a/Emilia/modules/commands/ud.py
+++ b/Emilia/modules/commands/ud.py
@@ -52,10 +52,7 @@ async def ud_command(client, message):
     try:
         await message.reply_text(reply_text, reply_markup=buttons)
     except ChatWriteForbidden:
-        try:
-            await message.reply_text(reply_text)
-        except Exception:
-            pass
+        await message.reply_text(reply_text)
 
 
 @register(pattern="define", disable=True)

--- a/Emilia/modules/commands/weather.py
+++ b/Emilia/modules/commands/weather.py
@@ -1,0 +1,97 @@
+import urllib.parse
+from pyrogram.enums import ParseMode
+from pyrogram.types import LinkPreviewOptions
+
+from Emilia import LOGGER
+from Emilia.custom_filter import register
+from Emilia.helper.disable import disable
+from Emilia.utils.async_http import get
+from Emilia.utils.decorators import *
+
+
+def get_weather_emoji(desc: str) -> str:
+    desc = desc.lower()
+    if "sunny" in desc or "clear" in desc:
+        return "☀️"
+    if "cloudy" in desc or "overcast" in desc or "partly cloudy" in desc:
+        return "☁️"
+    if "rain" in desc or "drizzle" in desc or "shower" in desc or "patchy rain" in desc:
+        return "🌧️"
+    if "snow" in desc or "flurry" in desc or "ice" in desc or "sleet" in desc:
+        return "❄️"
+    if "thunder" in desc or "storm" in desc:
+        return "⛈️"
+    if "fog" in desc or "mist" in desc or "haze" in desc:
+        return "🌫️"
+    return "🌡️"
+
+
+@usage("/weather [city]")
+@example("/weather Tokyo")
+@description("Get the current weather conditions for a city.")
+@register(pattern="weather", disable=True)
+@disable
+@exception
+@rate_limit(RATE_LIMIT_GENERAL)
+async def weather(client, message):
+    try:
+        query = message.text.split(None, 1)[1].strip()
+    except IndexError:
+        return await usage_string(message, weather)
+
+    if not query:
+        return await usage_string(message, weather)
+
+    status_msg = await message.reply_text(f"Fetching weather for `{query}`...")
+
+    try:
+        # Fetch weather from wttr.in in JSON format
+        url = f"https://wttr.in/{urllib.parse.quote(query)}?format=j1"
+        response = await get(url, timeout=10)
+        
+        if response.status_code != 200:
+            await status_msg.edit_text("Could not fetch weather data. Please make sure the city name is correct.")
+            return
+
+        data = response.json()
+        if not data or "current_condition" not in data:
+            await status_msg.edit_text("Could not find weather details for that location.")
+            return
+
+        cond = data["current_condition"][0]
+        temp = cond.get("temp_C", "N/A")
+        feels_like = cond.get("FeelsLikeC", "N/A")
+        humidity = cond.get("humidity", "N/A")
+        wind = cond.get("windspeedKmph", "N/A")
+        
+        desc = "N/A"
+        if "weatherDesc" in cond and cond["weatherDesc"]:
+            desc = cond["weatherDesc"][0].get("value", "N/A")
+
+        area = "Unknown Location"
+        country = ""
+        if "nearest_area" in data and data["nearest_area"]:
+            area_info = data["nearest_area"][0]
+            if "areaName" in area_info and area_info["areaName"]:
+                area = area_info["areaName"][0].get("value", "Unknown Area")
+            if "country" in area_info and area_info["country"]:
+                country = f", {area_info['country'][0].get('value', '')}"
+
+        emoji = get_weather_emoji(desc)
+        
+        result_text = (
+            f"⚡ **Weather report for {area}{country}**\n\n"
+            f"{emoji} **Condition:** `{desc}`\n"
+            f"🌡️ **Temperature:** `{temp}°C` (Feels like `{feels_like}°C`)\n"
+            f"💧 **Humidity:** `{humidity}%`\n"
+            f"💨 **Wind Speed:** `{wind} km/h`"
+        )
+        
+        await status_msg.edit_text(
+            result_text,
+            parse_mode=ParseMode.MARKDOWN,
+            link_preview_options=LinkPreviewOptions(is_disabled=True)
+        )
+    except Exception as e:
+        LOGGER.error(f"Error in weather command: {e}")
+        await status_msg.edit_text("An error occurred while fetching weather details.")

--- a/Emilia/modules/commands/wiki.py
+++ b/Emilia/modules/commands/wiki.py
@@ -54,13 +54,23 @@ async def wiki(client, message):
         result = "An error occurred while processing your request."
 
     if len(result) > 4000:
-        with open("result.txt", "w") as f:
-            f.write(f"{result}\n\nUwU OwO OmO UmU")
-        await client.send_document(
-            message.chat.id,
-            "result.txt",
-            file_name="result.txt",
-        )
+        import os
+        import uuid
+        filename = f"wiki_{uuid.uuid4().hex}.txt"
+        try:
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(f"{result}\n\nUwU OwO OmO UmU")
+            await client.send_document(
+                message.chat.id,
+                filename,
+                file_name="wiki_result.txt",
+            )
+        finally:
+            if os.path.exists(filename):
+                try:
+                    os.remove(filename)
+                except Exception:
+                    pass
     else:
         await message.reply_text(
             result, parse_mode=ParseMode.HTML, link_preview_options=LinkPreviewOptions(is_disabled=True)

--- a/Emilia/modules/plugins/lyrics.py
+++ b/Emilia/modules/plugins/lyrics.py
@@ -3,6 +3,7 @@ import re
 from dataclasses import dataclass
 
 from pyrogram import Client, enums
+from pyrogram.types import LinkPreviewOptions
 
 from Emilia import BOT_USERNAME, LOGGER, custom_filter
 from Emilia.helper.disable import disable

--- a/Emilia/utils/decorators.py
+++ b/Emilia/utils/decorators.py
@@ -200,6 +200,7 @@ async def get_telegram_info(client, event):
 
 
 def log_to_channel(func):
+    @wraps(func)
     async def wrapper(*args, **kwargs):
         log_message = " "
         client = args[0]
@@ -417,6 +418,7 @@ def rate_limit(limit_config=RATE_LIMIT_GENERAL):
     messages_per_window, window_seconds = limit_config
 
     def decorator(func):
+        @wraps(func)
         async def wrapper(*args, **kwargs):
             target = args[1] if args[1] is not None else args[0]
             user = getattr(target, "from_user", None)


### PR DESCRIPTION
- feat(weather): add asynchronous /weather command querying wttr.in
- feat(chatbot): add direct /chat command and cache enabled status using SimpleCache
- fix(concurrency): replace static file outputs with unique uuid-based filenames in carbon, logo, tts, and wiki commands
- fix(decorators): add missing @wraps(func) to rate_limit and log_to_channel decorators
- fix(lyrics): import missing LinkPreviewOptions to resolve NameError
- fix(ud): support multi-word queries in /ud and fix IndexError in /define
- feat(truthdare): add offline curated question fallbacks

## Summary by Sourcery

Add new bot commands and improve reliability, safety, and platform compatibility across multiple features.

New Features:
- Introduce an asynchronous /weather command that fetches current conditions from wttr.in.
- Add a direct /chat command for chatbot conversations without relying on replies.
- Provide offline fallback question sets for truth or dare when remote APIs fail.

Bug Fixes:
- Ensure generated media and text outputs use unique, temporary filenames in TTS, logo, carbon, and wiki commands to avoid concurrency conflicts and clean up files safely.
- Fix the Urban Dictionary /ud command to support multi-word queries and make /define more robust against missing input and encoding issues.
- Resolve missing LinkPreviewOptions import in the lyrics plugin to prevent runtime errors.
- Apply @wraps to log_to_channel and rate_limit decorators so wrapped functions preserve their metadata.

Enhancements:
- Cache chatbot enabled/disabled state per chat to reduce database lookups and speed up message handling.
- Make uvloop usage optional by gracefully falling back to asyncio.run when uvloop is unavailable.
- Improve user-facing help text for chatbot and misc commands, including documenting the new /weather command.